### PR TITLE
fix: remove hooks from build - they're completely unused

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,7 @@
       "@oclif/plugin-help",
       "@oclif/plugin-not-found"
     ],
-    "topicSeparator": " ",
-    "hooks": {
-      "init": "./src/hooks/init/log",
-      "command_not_found": "./src/hooks/command_not_found/log"
-    }
+    "topicSeparator": " "
   },
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",

--- a/src/hooks/command_not_found/log.ts
+++ b/src/hooks/command_not_found/log.ts
@@ -1,8 +1,0 @@
-import { Hook } from "@oclif/core";
-
-const hook: Hook<"command_not_found"> = async function (opts) {
-  process.stdout.write(`command "${opts.id}" not found\n`);
-  // this.exit();
-};
-
-export default hook;

--- a/src/hooks/init/log.ts
+++ b/src/hooks/init/log.ts
@@ -1,7 +1,0 @@
-import { Hook } from "@oclif/core";
-
-const hook: Hook<"init"> = async function (opts) {
-  // process.stdout.write(`example hook running ${opts.id}\n`)
-};
-
-export default hook;

--- a/test/hooks/command_not_found/log.test.ts
+++ b/test/hooks/command_not_found/log.test.ts
@@ -1,9 +1,0 @@
-import {expect, test} from '@oclif/test'
-
-describe('hooks', () => {
-  test
-  .stdout()
-  .hook('init', {id: 'mycommand'})
-  .do(output => expect(output.stdout).to.contain('example hook running mycommand'))
-  .it('shows a message')
-})

--- a/test/hooks/init/log.test.ts
+++ b/test/hooks/init/log.test.ts
@@ -1,9 +1,0 @@
-import {expect, test} from '@oclif/test'
-
-describe('hooks', () => {
-  test
-  .stdout()
-  .hook('init', {id: 'mycommand'})
-  .do(output => expect(output.stdout).to.contain('example hook running mycommand'))
-  .it('shows a message')
-})

--- a/test/hooks/postrun/log.test.ts
+++ b/test/hooks/postrun/log.test.ts
@@ -1,9 +1,0 @@
-import {expect, test} from '@oclif/test'
-
-describe('hooks', () => {
-  test
-  .stdout()
-  .hook('init', {id: 'mycommand'})
-  .do(output => expect(output.stdout).to.contain('example hook running mycommand'))
-  .it('shows a message')
-})

--- a/test/hooks/prerun/auth.test.ts
+++ b/test/hooks/prerun/auth.test.ts
@@ -1,9 +1,0 @@
-import {expect, test} from '@oclif/test'
-
-describe('hooks', () => {
-  test
-  .stdout()
-  .hook('init', {id: 'mycommand'})
-  .do(output => expect(output.stdout).to.contain('example hook running mycommand'))
-  .it('shows a message')
-})


### PR DESCRIPTION
<!-- Thanks for your intest in raising a PR against this project. -->

# Description

Removes the hooks as they're completely unused right now and causing issues on the install

Fixes #153

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?




# Checklist:



- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code in particularly hard-to-understand areas
- [x] I have made corresponding changes to the documentation or there are no corresponding changes to make
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with `yarn test`
- [x] Any dependent changes have been merged and published in downstream modules
